### PR TITLE
Create mock Pi duel MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# chatgptpi
+# Pi Duel Arena (MVP)
+
+Pi Duel Arena on 1v1 online duelliplatvormi esmane MVP-versioon. See keskkond võimaldab mängijatel harjutada oskuspõhist kivi-paber-käärid duelli mock Pi tokenitega, luua lobby’sid ning kogeda automaatset escrow loogikat enne päris Pi Network integratsiooni.
+
+## Funktsioonid
+
+- 🔐 **Mock login** – vali kasutajanimi ja saa koheselt 1000π saldo.
+- 🏠 **Lobby süsteem** – loo buy-in’iga lobby, üks mängija lobby kohta.
+- ⚔️ **PvP duellid** – kui teine mängija liitub, alustatakse best-of-3 kivi/paber/kääride matš automaatse escrow’ga.
+- 🤖 **AI treeningrežiim** – harjuta koheselt AI vastasega (valib liigutusi ajaloo põhjal).
+- ⏱️ **AFK kaitse** – kui vastane ei tee 10 sekundi jooksul käiku, loetakse raund sinu kasuks.
+- 💰 **Escrow + tasud** – mõlemad panustavad buy-in’i, võitja saab 90% potist, 10% jääb süsteemile.
+- 📊 **Statistika ja profiil** – võidud, kaotused, netovõit, hiljutised mängud.
+
+Kõik andmed hoitakse mälu sees (mock Supabase). Taaskäivituse järel läheb olukord nulli.
+
+## Struktuur
+
+```
+.
+├── public/           # Statiline SPA (HTML, CSS, JS)
+├── server/           # Node.js HTTP server ja mänguloogika
+├── package.json
+└── README.md
+```
+
+## Käivitamine
+
+1. Veendu, et sul on paigaldatud Node.js (>=18).
+2. Käivita server:
+
+   ```bash
+   npm start
+   ```
+
+3. Ava brauseris [http://localhost:3000](http://localhost:3000) ja logi sisse mock kasutajaga.
+
+## Arhitektuuri märksõnad
+
+- **server/store.js** hoiab mängijaid, lobby’sid ja mänge mälu sees ning realiseerib escrow + AFK loogika.
+- **server/server.js** pakub lihtsaid REST API lõppe ja teenindab SPA-d.
+- **public/app.js** on vanilla JavaScript SPA, mis haldab sessiooni, lobby’sid ja mänguvaadet.
+
+## Tulevikutöö
+
+- Supabase / Pi Network wallet’i integreerimine päris andmete jaoks.
+- Reaalajas sündmused (WebSocket/SSE) lobby ja mängu uuendusteks.
+- Sõbralisti, kutsete ja lobby chati realiseerimine.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pi-duel-arena",
+  "version": "0.1.0",
+  "description": "Mock 1v1 duel platform MVP for Pi Network ecosystem.",
+  "main": "server/server.js",
+  "scripts": {
+    "start": "node server/server.js"
+  },
+  "keywords": ["pi", "duel", "pvp", "mvp"],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,706 @@
+const state = {
+  user: null,
+  lobbies: [],
+  games: [],
+  view: 'dashboard',
+  currentGameId: null,
+  currentGame: null,
+  pollHandle: null,
+  gamePollHandle: null,
+  profile: null,
+  profileLoading: false,
+};
+
+const MOVES = [
+  { key: 'rock', label: 'Kivi 🪨' },
+  { key: 'paper', label: 'Paber 📄' },
+  { key: 'scissors', label: 'Käärid ✂️' },
+];
+
+const appEl = document.getElementById('app');
+const toastEl = document.getElementById('toast');
+const navDashboard = document.getElementById('nav-dashboard');
+const navProfile = document.getElementById('nav-profile');
+const navLogout = document.getElementById('nav-logout');
+const navBar = document.querySelector('.top-bar__nav');
+
+navDashboard.addEventListener('click', () => {
+  if (!state.user) return;
+  state.view = 'dashboard';
+  state.profile = null;
+  render();
+});
+
+navProfile.addEventListener('click', () => {
+  if (!state.user) return;
+  state.view = 'profile';
+  loadProfile(state.user.username);
+});
+
+navLogout.addEventListener('click', async () => {
+  if (!state.user) return;
+  try {
+    await api('/api/auth/logout', { method: 'POST' });
+  } catch (error) {
+    console.error('Logout failed', error);
+  }
+  stopPolling();
+  resetState();
+  render();
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    stopPolling();
+  } else if (state.user) {
+    startPolling();
+  }
+});
+
+init();
+
+async function init() {
+  await refreshSession();
+  if (state.user) {
+    startPolling();
+  }
+  render();
+}
+
+function resetState() {
+  state.user = null;
+  state.lobbies = [];
+  state.games = [];
+  state.view = 'dashboard';
+  state.currentGameId = null;
+  state.currentGame = null;
+  state.profile = null;
+  updateNavVisibility();
+}
+
+function startPolling() {
+  stopPolling();
+  fetchDashboard();
+  state.pollHandle = setInterval(fetchDashboard, 4000);
+  if (state.currentGameId) {
+    startGamePolling(state.currentGameId);
+  }
+}
+
+function stopPolling() {
+  if (state.pollHandle) {
+    clearInterval(state.pollHandle);
+    state.pollHandle = null;
+  }
+  if (state.gamePollHandle) {
+    clearInterval(state.gamePollHandle);
+    state.gamePollHandle = null;
+  }
+}
+
+async function refreshSession() {
+  try {
+    const { user } = await api('/api/auth/session');
+    state.user = user;
+    updateNavVisibility();
+  } catch (error) {
+    console.error('Failed to load session', error);
+  }
+}
+
+async function fetchDashboard() {
+  if (!state.user) return;
+  try {
+    const [sessionRes, lobbiesRes, gamesRes] = await Promise.all([
+      api('/api/auth/session'),
+      api('/api/lobbies'),
+      api('/api/games'),
+    ]);
+    state.user = sessionRes.user;
+    state.lobbies = lobbiesRes.lobbies || [];
+    state.games = gamesRes.games || [];
+    updateNavVisibility();
+    if (state.view === 'profile' && state.profile) {
+      loadProfile(state.profile.user.username);
+    }
+    render();
+  } catch (error) {
+    console.error('Failed to refresh dashboard', error);
+    if (error.status === 401) {
+      stopPolling();
+      resetState();
+      render();
+    }
+  }
+}
+
+function updateNavVisibility() {
+  if (!navBar) return;
+  if (state.user) {
+    navBar.classList.remove('hidden');
+    navLogout.disabled = false;
+    navProfile.disabled = false;
+    navDashboard.disabled = false;
+  } else {
+    navBar.classList.add('hidden');
+    navLogout.disabled = true;
+    navProfile.disabled = true;
+    navDashboard.disabled = true;
+  }
+}
+
+function render() {
+  if (!state.user) {
+    renderLogin();
+    return;
+  }
+  switch (state.view) {
+    case 'game':
+      renderGame();
+      break;
+    case 'profile':
+      renderProfile();
+      break;
+    default:
+      renderDashboard();
+      break;
+  }
+}
+
+function renderLogin() {
+  appEl.innerHTML = `
+    <section class="card" aria-labelledby="login-title">
+      <h2 id="login-title">Logi sisse</h2>
+      <p class="subtitle">Sisesta oma kasutajanimi, et alustada mock-kogemust.</p>
+      <form id="login-form" class="login-form">
+        <label for="username">Kasutajanimi</label>
+        <input type="text" id="username" name="username" minlength="3" maxlength="24" required placeholder="nt. pi-warrior" />
+        <button type="submit" class="primary">Alusta duelle</button>
+      </form>
+    </section>
+  `;
+  const form = document.getElementById('login-form');
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const username = form.username.value.trim();
+    if (!username) return;
+    try {
+      const { user } = await api('/api/auth/login', {
+        method: 'POST',
+        body: { username },
+      });
+      state.user = user;
+      updateNavVisibility();
+      state.view = 'dashboard';
+      showToast(`Tere tulemast, ${user.username}!`, false);
+      startPolling();
+      render();
+    } catch (error) {
+      showToast(error.message || 'Login ebaõnnestus', true);
+    }
+  });
+}
+
+function renderDashboard() {
+  const { stats } = state.user;
+  const netClass = stats.netEarnings > 0 ? 'balance--positive' : stats.netEarnings < 0 ? 'balance--negative' : '';
+  const activeGames = state.games.filter((game) => game.status === 'in_progress');
+  const recentGames = state.games.filter((game) => game.status === 'completed').slice(0, 5);
+
+  appEl.innerHTML = `
+    <section class="grid-2">
+      <article class="card">
+        <h2>Minu konto</h2>
+        <p class="subtitle">Mock Pi saldo: <strong class="balance">${state.user.balance.toFixed(2)} π</strong></p>
+        <div class="stat-row"><span>Võidud</span><span>${stats.wins}</span></div>
+        <div class="stat-row"><span>Kaotused</span><span>${stats.losses}</span></div>
+        <div class="stat-row"><span>Mängud kokku</span><span>${stats.gamesPlayed}</span></div>
+        <div class="stat-row"><span>Netovõit</span><span class="${netClass}">${stats.netEarnings.toFixed(2)} π</span></div>
+      </article>
+      <article class="card">
+        <h2>Loo uus lobby</h2>
+        <p class="subtitle">Määra buy-in ja kutsu vastane duellile.</p>
+        <form id="create-lobby-form" class="lobby-form">
+          <label for="buy-in">Buy-in (π)</label>
+          <input type="number" id="buy-in" name="buyIn" min="1" step="1" required placeholder="nt. 25" />
+          <button type="submit" class="primary">Loo lobby</button>
+        </form>
+        ${state.user.lobbyId ? '<p class="subtitle">Sul on aktiivne lobby – vaata allpool.</p>' : ''}
+      </article>
+    </section>
+
+    <section class="card">
+      <div class="section-header">
+        <h2>Aktiivsed lobbyd</h2>
+        <span class="tag">Escrow 90/10</span>
+      </div>
+      <div id="lobby-list" class="lobby-list"></div>
+    </section>
+
+    <section class="card">
+      <div class="section-header">
+        <h2>Minu mängud</h2>
+        <button id="start-ai" class="secondary">Harjuta AI vastu</button>
+      </div>
+      <div id="game-list" class="game-list"></div>
+      <div id="recent-games" class="game-list"></div>
+    </section>
+  `;
+
+  const lobbyForm = document.getElementById('create-lobby-form');
+  lobbyForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const buyIn = Number(lobbyForm.buyIn.value);
+    if (!Number.isFinite(buyIn) || buyIn <= 0) {
+      showToast('Buy-in peab olema positiivne arv.', true);
+      return;
+    }
+    try {
+      await api('/api/lobbies', {
+        method: 'POST',
+        body: { buyIn },
+      });
+      lobbyForm.reset();
+      showToast('Lobby loodud. Oota vastast!', false);
+      fetchDashboard();
+    } catch (error) {
+      showToast(error.message || 'Lobby loomine ebaõnnestus', true);
+    }
+  });
+
+  document.getElementById('start-ai').addEventListener('click', async () => {
+    try {
+      const { game } = await api('/api/ai/start', { method: 'POST', body: {} });
+      openGame(game.id, game);
+      showToast('AI duell alustatud!', false);
+    } catch (error) {
+      showToast(error.message || 'AI käivitamine ebaõnnestus', true);
+    }
+  });
+
+  renderLobbyList();
+  renderGameLists(activeGames, recentGames);
+}
+
+function renderLobbyList() {
+  const container = document.getElementById('lobby-list');
+  if (!container) return;
+  if (state.lobbies.length === 0) {
+    container.innerHTML = '<div class="empty-state">Praegu pole ühtegi avatud lobbyt. Loo uus ja väljakutse sõber!</div>';
+    return;
+  }
+
+  container.innerHTML = state.lobbies
+    .map((lobby) => {
+      const isHost = lobby.hostId === state.user.id;
+      return `
+        <article class="lobby-item">
+          <div class="lobby-item__header">
+            <div>
+              <strong>${lobby.hostUsername}</strong>
+              <p class="subtitle">Buy-in: ${lobby.buyIn} π</p>
+            </div>
+            <div>
+              ${isHost ? '<span class="tag">Sinu lobby</span>' : '<span class="tag tag--success">Avatud</span>'}
+            </div>
+          </div>
+          <div class="lobby-item__actions">
+            ${isHost ? `<button class="secondary" data-cancel="${lobby.id}">Tühista</button>` : `<button class="primary" data-join="${lobby.id}">Liitu</button>`}
+          </div>
+        </article>
+      `;
+    })
+    .join('');
+
+  container.querySelectorAll('[data-join]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const lobbyId = btn.getAttribute('data-join');
+      try {
+        const { game } = await api(`/api/lobbies/${lobbyId}/join`, { method: 'POST', body: {} });
+        showToast('Liitusid lobbyga!');
+        openGame(game.id, game);
+      } catch (error) {
+        showToast(error.message || 'Liitumine ebaõnnestus', true);
+      }
+    });
+  });
+
+  container.querySelectorAll('[data-cancel]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const lobbyId = btn.getAttribute('data-cancel');
+      try {
+        await api(`/api/lobbies/${lobbyId}`, { method: 'DELETE' });
+        showToast('Lobby tühistatud.');
+        fetchDashboard();
+      } catch (error) {
+        showToast(error.message || 'Tühistamine ebaõnnestus', true);
+      }
+    });
+  });
+}
+
+function renderGameLists(activeGames, recentGames) {
+  const activeContainer = document.getElementById('game-list');
+  const recentContainer = document.getElementById('recent-games');
+  if (activeGames.length === 0) {
+    activeContainer.innerHTML = '<div class="empty-state">Sul pole aktiivseid mänge. Liitu lobbyga ja alusta duelli!</div>';
+  } else {
+    activeContainer.innerHTML = activeGames
+      .map((game) => {
+        const opponent = game.players.find((p) => p.userId !== state.user.id);
+        return `
+          <article class="game-item">
+            <div class="game-item__header">
+              <div>
+                <strong>${opponent ? opponent.username : 'AI vastane'}</strong>
+                <p class="subtitle">Võidud: ${scoreLine(game)}</p>
+              </div>
+              <span class="tag tag--success">Kestab</span>
+            </div>
+            <button class="primary" data-open-game="${game.id}">Ava mäng</button>
+          </article>
+        `;
+      })
+      .join('');
+    activeContainer.querySelectorAll('[data-open-game]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const gameId = btn.getAttribute('data-open-game');
+        openGame(gameId);
+      });
+    });
+  }
+
+  if (recentGames.length === 0) {
+    recentContainer.innerHTML = '';
+  } else {
+    recentContainer.innerHTML = `
+      <h3>Hiljutised tulemused</h3>
+      ${recentGames
+        .map((game) => {
+          const opponent = game.players.find((p) => p.userId !== state.user.id);
+          const didWin = game.winnerId === state.user.id;
+          return `
+            <article class="game-item">
+              <div class="game-item__header">
+                <div>
+                  <strong>${opponent ? opponent.username : 'AI vastane'}</strong>
+                  <p class="subtitle">${didWin ? 'Võit' : 'Kaotus'} · Skor: ${scoreLine(game)}</p>
+                </div>
+                <span class="tag ${didWin ? 'tag--success' : 'tag--danger'}">${didWin ? 'Võit' : 'Kaotus'}</span>
+              </div>
+              <button class="secondary" data-open-game="${game.id}">Ava</button>
+            </article>
+          `;
+        })
+        .join('')}
+    `;
+    recentContainer.querySelectorAll('[data-open-game]').forEach((btn) => {
+      btn.addEventListener('click', () => openGame(btn.getAttribute('data-open-game')));
+    });
+  }
+}
+
+function openGame(gameId, initialGame) {
+  state.view = 'game';
+  state.currentGameId = gameId;
+  if (initialGame) {
+    state.currentGame = initialGame;
+  }
+  render();
+  startGamePolling(gameId);
+}
+
+function startGamePolling(gameId) {
+  if (state.gamePollHandle) {
+    clearInterval(state.gamePollHandle);
+  }
+  fetchGame(gameId);
+  state.gamePollHandle = setInterval(() => fetchGame(gameId), 1500);
+}
+
+async function fetchGame(gameId) {
+  if (!gameId) return;
+  try {
+    const { game } = await api(`/api/games/${gameId}`);
+    state.currentGame = game;
+    if (game.status === 'completed') {
+      clearInterval(state.gamePollHandle);
+      state.gamePollHandle = null;
+      showToast('Mäng lõppes!', false);
+      fetchDashboard();
+    }
+    render();
+  } catch (error) {
+    console.error('Game fetch error', error);
+    showToast(error.message || 'Mängu uuendamine ebaõnnestus', true);
+  }
+}
+
+function renderGame() {
+  if (!state.currentGame) {
+    appEl.innerHTML = '<section class="card"><p>Laen mängu andmeid...</p></section>';
+    return;
+  }
+  const game = state.currentGame;
+  const me = game.players.find((p) => p.userId === state.user.id);
+  const opponent = game.players.find((p) => p.userId !== state.user.id);
+  const currentRound = game.rounds[game.rounds.length - 1];
+  const myMove = currentRound.moves[state.user.id];
+  const opponentMove = opponent && currentRound.moves[opponent.userId];
+  const secondsLeft = Math.max(0, Math.ceil((currentRound.deadline - Date.now()) / 1000));
+  const inProgress = game.status === 'in_progress';
+
+  appEl.innerHTML = `
+    <section class="game-view">
+      <article class="card">
+        <button class="secondary" id="back-to-dashboard">← Tagasi</button>
+        <h2>Mäng vs ${opponent ? opponent.username : 'Pi Duel AI'}</h2>
+        <p class="subtitle">Best-of-3 · 10s AFK taimer</p>
+        <div class="grid-3">
+          <div>
+            <h3>Sina</h3>
+            <p class="balance">${me.wins}</p>
+            <p class="subtitle">Võidud</p>
+          </div>
+          <div>
+            <h3>Vastane</h3>
+            <p class="balance">${opponent ? opponent.wins : 0}</p>
+            <p class="subtitle">Võidud</p>
+          </div>
+          <div>
+            <h3>Taimer</h3>
+            <p class="timer">${secondsLeft}s</p>
+            <p class="subtitle">Praeguse raundi tähtaeg</p>
+          </div>
+        </div>
+      </article>
+
+      <article class="card">
+        <h3>Praegune raund: ${currentRound.round}</h3>
+        <div class="move-buttons">
+          ${MOVES.map(
+            (move) => `
+              <button
+                class="move-btn"
+                data-move="${move.key}"
+                ${!inProgress || myMove ? 'disabled' : ''}
+              >${move.label}</button>
+            `
+          ).join('')}
+        </div>
+        <p class="subtitle">
+          Sinu käik: ${myMove ? moveLabel(myMove.choice) : 'pole veel valitud'} · 
+          Vastase käik: ${opponentMove ? moveLabel(opponentMove.choice) : 'ootel'}
+        </p>
+      </article>
+
+      <article class="card">
+        <h3>Raundid</h3>
+        <div class="round-grid">
+          ${game.rounds
+            .map((round) => {
+              const my = round.moves[state.user.id];
+              const opp = opponent ? round.moves[opponent.userId] : null;
+              const status = round.winnerId
+                ? round.winnerId === state.user.id
+                  ? '<span class="tag tag--success">Võitsid</span>'
+                  : '<span class="tag tag--danger">Kaotasid</span>'
+                : '<span class="tag">Kestab / Viik</span>';
+              return `
+                <div class="round-card">
+                  <div class="lobby-item__header">
+                    <strong>Raund ${round.round}</strong>
+                    ${status}
+                  </div>
+                  <p class="subtitle">Sina: ${my ? moveLabel(my.choice) : '—'} · Vastane: ${opp ? moveLabel(opp.choice) : '—'}</p>
+                </div>
+              `;
+            })
+            .join('')}
+        </div>
+      </article>
+
+      ${game.status === 'completed'
+        ? `<article class="card">
+            <h3>Mäng on lõppenud</h3>
+            <p>${game.winnerId === state.user.id ? 'Palju õnne! Võitsid duelli.' : 'Seekord vedas vastasel rohkem.'}</p>
+            <button class="primary" id="back-dashboard-finish">Tagasi avalehele</button>
+          </article>`
+        : ''}
+    </section>
+  `;
+
+  document.getElementById('back-to-dashboard').addEventListener('click', () => {
+    state.view = 'dashboard';
+    state.currentGameId = null;
+    state.currentGame = null;
+    if (state.gamePollHandle) {
+      clearInterval(state.gamePollHandle);
+      state.gamePollHandle = null;
+    }
+    render();
+  });
+
+  const finishBtn = document.getElementById('back-dashboard-finish');
+  if (finishBtn) {
+    finishBtn.addEventListener('click', () => {
+      state.view = 'dashboard';
+      state.currentGameId = null;
+      state.currentGame = null;
+      render();
+    });
+  }
+
+  document.querySelectorAll('[data-move]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const move = btn.getAttribute('data-move');
+      try {
+        const { game } = await api(`/api/games/${game.id}/move`, {
+          method: 'POST',
+          body: { move },
+        });
+        state.currentGame = game;
+        if (game.status === 'completed') {
+          clearInterval(state.gamePollHandle);
+          state.gamePollHandle = null;
+          fetchDashboard();
+        }
+        render();
+      } catch (error) {
+        showToast(error.message || 'Käigu saatmine ebaõnnestus', true);
+      }
+    });
+  });
+}
+
+function renderProfile() {
+  if (state.profileLoading) {
+    appEl.innerHTML = '<section class="card"><p>Laen profiili...</p></section>';
+    return;
+  }
+  if (!state.profile) {
+    appEl.innerHTML = '<section class="card"><p>Profiili ei leitud.</p></section>';
+    return;
+  }
+  const { user, lobbies, games } = state.profile;
+  const netClass = user.stats.netEarnings > 0 ? 'balance--positive' : user.stats.netEarnings < 0 ? 'balance--negative' : '';
+
+  appEl.innerHTML = `
+    <section class="grid-2">
+      <article class="card">
+        <h2>${user.username}</h2>
+        <p class="subtitle">Liitus: ${new Date(user.createdAt || Date.now()).toLocaleDateString()}</p>
+        <div class="stat-row"><span>Võidud</span><span>${user.stats.wins}</span></div>
+        <div class="stat-row"><span>Kaotused</span><span>${user.stats.losses}</span></div>
+        <div class="stat-row"><span>Mänge</span><span>${user.stats.gamesPlayed}</span></div>
+        <div class="stat-row"><span>Netovõit</span><span class="${netClass}">${user.stats.netEarnings.toFixed(2)} π</span></div>
+      </article>
+      <article class="card">
+        <h2>Aktiivsus</h2>
+        <p class="subtitle">Aktiivsed lobbyd: ${lobbies.length}</p>
+        <p class="subtitle">Aktiivsed mängud: ${games.filter((g) => g.status === 'in_progress').length}</p>
+      </article>
+    </section>
+    <section class="card">
+      <h3>Hiljutised mängud</h3>
+      <div class="game-list">
+        ${games.length === 0
+          ? '<div class="empty-state">Veel pole mänge.</div>'
+          : games
+              .map((game) => {
+                const opponent = game.players.find((p) => p.userId !== user.id);
+                const didWin = game.winnerId === user.id;
+                return `
+                  <article class="game-item">
+                    <div class="game-item__header">
+                      <div>
+                        <strong>${opponent ? opponent.username : 'AI vastane'}</strong>
+                        <p class="subtitle">${game.status === 'completed' ? (didWin ? 'Võit' : 'Kaotus') : 'Kestab'} · Skor: ${scoreLine(game)}</p>
+                      </div>
+                      <span class="tag ${game.status === 'completed' ? (didWin ? 'tag--success' : 'tag--danger') : ''}">${
+                  game.status === 'completed' ? (didWin ? 'Võit' : 'Kaotus') : 'Käimas'
+                }</span>
+                    </div>
+                  </article>
+                `;
+              })
+              .join('')}
+      </div>
+    </section>
+  `;
+}
+
+async function loadProfile(username) {
+  state.profileLoading = true;
+  renderProfile();
+  try {
+    const profile = await api(`/api/profile/${encodeURIComponent(username)}`);
+    state.profile = profile;
+  } catch (error) {
+    state.profile = null;
+    showToast(error.message || 'Profiili laadimine ebaõnnestus', true);
+  } finally {
+    state.profileLoading = false;
+    renderProfile();
+  }
+}
+
+function scoreLine(game) {
+  const [a, b] = game.players;
+  if (!a && !b) return '0 : 0';
+  if (a && !b) return `${a.wins} : 0`;
+  if (!a && b) return `0 : ${b.wins}`;
+  return `${a.wins} : ${b.wins}`;
+}
+
+function moveLabel(move) {
+  switch (move) {
+    case 'rock':
+      return 'Kivi';
+    case 'paper':
+      return 'Paber';
+    case 'scissors':
+      return 'Käärid';
+    default:
+      return move;
+  }
+}
+
+async function api(path, { method = 'GET', body } = {}) {
+  const options = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  };
+  if (body && (method === 'POST' || method === 'PUT' || method === 'DELETE')) {
+    options.body = JSON.stringify(body);
+  }
+  const response = await fetch(path, options);
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = null;
+  }
+  if (!response.ok) {
+    const message = payload && payload.error ? payload.error : `Viga (${response.status})`;
+    const err = new Error(message);
+    err.status = response.status;
+    throw err;
+  }
+  return payload || {};
+}
+
+let toastTimeout = null;
+function showToast(message, isError = false) {
+  if (!toastEl) return;
+  toastEl.textContent = message;
+  toastEl.classList.toggle('error', isError);
+  toastEl.classList.add('show');
+  if (toastTimeout) clearTimeout(toastTimeout);
+  toastTimeout = setTimeout(() => {
+    toastEl.classList.remove('show');
+  }, 2500);
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pi Duel Arena</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="top-bar">
+      <div class="top-bar__branding">
+        <span class="logo">⚡</span>
+        <div>
+          <h1>Pi Duel Arena</h1>
+          <p class="subtitle">1v1 oskuspõhised mängud Pi kogukonnale</p>
+        </div>
+      </div>
+      <nav class="top-bar__nav hidden">
+        <button id="nav-dashboard" class="nav-btn" data-view="dashboard">Avaleht</button>
+        <button id="nav-profile" class="nav-btn" data-view="profile">Minu profiil</button>
+        <button id="nav-logout" class="nav-btn nav-btn--danger">Logi välja</button>
+      </nav>
+    </header>
+    <main id="app" class="app-shell"></main>
+    <div id="toast" class="toast" aria-live="polite" aria-atomic="true"></div>
+    <footer class="footer">
+      <p>
+        MVP: mock tokenid ja mock login. Tulevikus Pi Network testnet/pärisnet integratsioon.
+      </p>
+    </footer>
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,383 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f1729;
+  --surface: #182642;
+  --surface-alt: #1f3358;
+  --primary: #eab308;
+  --primary-soft: rgba(234, 179, 8, 0.15);
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --danger: #f87171;
+  --success: #4ade80;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(250, 204, 21, 0.1), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  backdrop-filter: blur(18px);
+  background: linear-gradient(90deg, rgba(24, 38, 66, 0.9), rgba(31, 51, 88, 0.75));
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.top-bar__branding {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.top-bar__branding h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.logo {
+  background: var(--primary-soft);
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-content: center;
+  font-size: 1.4rem;
+}
+
+.top-bar__nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.nav-btn {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.1s ease, background 0.2s ease;
+  font-weight: 600;
+}
+
+.nav-btn:hover {
+  background: rgba(148, 163, 184, 0.15);
+  transform: translateY(-1px);
+}
+
+.nav-btn--danger {
+  border-color: rgba(248, 113, 113, 0.3);
+  color: var(--danger);
+}
+
+.nav-btn--danger:hover {
+  background: rgba(248, 113, 113, 0.15);
+}
+
+.app-shell {
+  width: min(1100px, 92%);
+  margin: 2rem auto;
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: linear-gradient(135deg, rgba(31, 51, 88, 0.9), rgba(15, 23, 41, 0.8));
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.4);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+}
+
+.grid-2 {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid-3 {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+input[type='text'],
+input[type='number'],
+select {
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+
+button.primary {
+  background: linear-gradient(120deg, rgba(234, 179, 8, 1), rgba(234, 179, 8, 0.75));
+  border: none;
+  color: #0f1729;
+  font-weight: 700;
+  padding: 0.75rem 1.2rem;
+  border-radius: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(234, 179, 8, 0.35);
+}
+
+button.secondary {
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--text);
+  padding: 0.65rem 1rem;
+  border-radius: 0.9rem;
+  cursor: pointer;
+}
+
+button.secondary:hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.login-form,
+.lobby-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.lobby-list,
+.game-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+.lobby-item,
+.game-item {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.65);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.lobby-item__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.lobby-item__header,
+.game-item__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tag {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--muted);
+}
+
+.tag--success {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--success);
+}
+
+.tag--danger {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+}
+
+.stat-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0;
+  border-bottom: 1px dashed rgba(148, 163, 184, 0.15);
+}
+
+.stat-row:last-child {
+  border-bottom: none;
+}
+
+.balance {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.balance--positive {
+  color: var(--success);
+}
+
+.balance--negative {
+  color: var(--danger);
+}
+
+.toast {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.9rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.error {
+  border-color: rgba(248, 113, 113, 0.65);
+  color: var(--danger);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2rem 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--muted);
+}
+
+.game-view {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.round-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.round-card {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.move-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.move-btn {
+  flex: 1 1 120px;
+  padding: 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.1s ease, border 0.1s ease;
+}
+
+.move-btn:hover {
+  transform: translateY(-2px);
+  border-color: rgba(234, 179, 8, 0.8);
+}
+
+.move-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.timer {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.footer {
+  text-align: center;
+  padding: 1.5rem 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .top-bar__nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .app-shell {
+    margin-top: 1.5rem;
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,290 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+const { store, MOVE_VALUES } = require('./store');
+
+const PORT = process.env.PORT || 3000;
+const PUBLIC_DIR = path.join(__dirname, '..', 'public');
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+
+    if (req.method === 'OPTIONS') {
+      return handleOptions(req, res);
+    }
+
+    if (url.pathname.startsWith('/api/')) {
+      await handleApi(req, res, url);
+      return;
+    }
+
+    await serveStatic(req, res, url);
+  } catch (error) {
+    console.error('Server error', error);
+    sendJson(res, 500, { error: 'Internal server error.' });
+  }
+});
+
+function handleOptions(req, res) {
+  const headers = {
+    'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+  if (req.headers.origin) {
+    headers['Access-Control-Allow-Origin'] = req.headers.origin;
+    headers['Access-Control-Allow-Credentials'] = 'true';
+    headers.Vary = 'Origin';
+  } else {
+    headers['Access-Control-Allow-Origin'] = '*';
+  }
+  res.writeHead(204, headers);
+  res.end();
+}
+
+async function handleApi(req, res, url) {
+  const token = parseCookies(req).session || null;
+  try {
+    if (req.method === 'POST' && url.pathname === '/api/auth/login') {
+      const body = await parseBody(req);
+      const { username } = body;
+      const { token: sessionToken, user } = store.createSession(username);
+      sendJson(
+        req,
+        res,
+        200,
+        { user },
+        {
+          'Set-Cookie': cookieHeader('session', sessionToken, {
+            httpOnly: true,
+            maxAge: 60 * 60 * 24 * 30,
+          }),
+        }
+      );
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/auth/logout') {
+      if (token) {
+        store.endSession(token);
+      }
+      sendJson(
+        req,
+        res,
+        200,
+        { success: true },
+        {
+          'Set-Cookie': cookieHeader('session', '', {
+            httpOnly: true,
+            maxAge: 0,
+          }),
+        }
+      );
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/auth/session') {
+      const user = store.getUserBySession(token);
+      sendJson(req, res, 200, { user });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/lobbies') {
+      const lobbies = store.listLobbies();
+      sendJson(req, res, 200, { lobbies });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/lobbies') {
+      const body = await parseBody(req);
+      const lobby = store.createLobby(token, body || {});
+      sendJson(req, res, 201, { lobby });
+      return;
+    }
+
+    if (req.method === 'DELETE' && url.pathname.startsWith('/api/lobbies/')) {
+      const lobbyId = url.pathname.split('/')[3];
+      const result = store.cancelLobby(token, lobbyId);
+      sendJson(req, res, 200, result);
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname.startsWith('/api/lobbies/') && url.pathname.endsWith('/join')) {
+      const parts = url.pathname.split('/');
+      const lobbyId = parts[3];
+      const game = store.joinLobby(token, lobbyId);
+      sendJson(req, res, 200, { game });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/games') {
+      const user = store.requireUser(token);
+      const games = store.listUserGames(user.id);
+      sendJson(req, res, 200, { games });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname.startsWith('/api/games/')) {
+      const gameId = url.pathname.split('/')[3];
+      const game = store.getGame(gameId);
+      if (!game) {
+        sendJson(req, res, 404, { error: 'Game not found.' });
+        return;
+      }
+      sendJson(req, res, 200, { game });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname.startsWith('/api/games/') && url.pathname.endsWith('/move')) {
+      const parts = url.pathname.split('/');
+      const gameId = parts[3];
+      const body = await parseBody(req);
+      const { move } = body || {};
+      const game = store.submitMove(token, gameId, move);
+      sendJson(req, res, 200, { game });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/ai/start') {
+      const body = await parseBody(req);
+      const game = store.startAiGame(token, body || {});
+      sendJson(req, res, 201, { game });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname.startsWith('/api/profile/')) {
+      const username = decodeURIComponent(url.pathname.split('/')[3] || '');
+      const profile = store.getProfile(username);
+      if (!profile) {
+        sendJson(req, res, 404, { error: 'Profile not found.' });
+        return;
+      }
+      sendJson(req, res, 200, profile);
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/constants') {
+      sendJson(req, res, 200, { moves: MOVE_VALUES });
+      return;
+    }
+
+    sendJson(req, res, 404, { error: 'Not found.' });
+  } catch (error) {
+    console.error('API error', error);
+    sendJson(req, res, 400, { error: error.message || 'Request failed.' });
+  }
+}
+
+async function serveStatic(req, res, url) {
+  let filePath = path.join(PUBLIC_DIR, url.pathname === '/' ? '/index.html' : url.pathname);
+  if (filePath.endsWith('/')) {
+    filePath = path.join(filePath, 'index.html');
+  }
+  try {
+    const stat = await fs.promises.stat(filePath);
+    if (stat.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+    const stream = fs.createReadStream(filePath);
+    res.writeHead(200, { 'Content-Type': contentType(filePath) });
+    stream.pipe(res);
+  } catch (error) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+}
+
+function sendJson(req, res, statusCode, payload, extraHeaders = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...extraHeaders,
+  };
+  if (req.headers.origin) {
+    headers['Access-Control-Allow-Origin'] = req.headers.origin;
+    headers['Access-Control-Allow-Credentials'] = 'true';
+    headers.Vary = 'Origin';
+  } else {
+    headers['Access-Control-Allow-Origin'] = '*';
+  }
+  res.writeHead(statusCode, headers);
+  res.end(JSON.stringify(payload));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > 1e6) {
+        reject(new Error('Payload too large.'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(new Error('Invalid JSON payload.'));
+      }
+    });
+  });
+}
+
+function parseCookies(req) {
+  const header = req.headers.cookie || '';
+  const result = {};
+  header.split(';').forEach((pair) => {
+    const [key, value] = pair.split('=').map((part) => part && part.trim());
+    if (key && value) {
+      result[key] = decodeURIComponent(value);
+    }
+  });
+  return result;
+}
+
+function cookieHeader(name, value, { httpOnly = false, maxAge = null } = {}) {
+  const parts = [`${name}=${encodeURIComponent(value)}`];
+  if (httpOnly) parts.push('HttpOnly');
+  parts.push('Path=/');
+  parts.push('SameSite=Lax');
+  if (maxAge !== null) {
+    parts.push(`Max-Age=${maxAge}`);
+  }
+  return parts.join('; ');
+}
+
+function contentType(filePath) {
+  const ext = path.extname(filePath);
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = { server };

--- a/server/store.js
+++ b/server/store.js
@@ -1,0 +1,629 @@
+const { randomUUID } = require('crypto');
+
+const MOVE_VALUES = ['rock', 'paper', 'scissors'];
+const WIN_MAP = {
+  rock: 'scissors',
+  paper: 'rock',
+  scissors: 'paper',
+};
+
+const ROUND_TIME_LIMIT_MS = 10000;
+const MAX_ROUND_WINS = 2;
+const SYSTEM_FEE_RATIO = 0.1;
+
+class GameStore {
+  constructor() {
+    this.users = new Map();
+    this.usersByName = new Map();
+    this.sessions = new Map();
+    this.lobbies = new Map();
+    this.games = new Map();
+    this.houseEarnings = 0;
+  }
+
+  _ensureUsername(username) {
+    if (!username || typeof username !== 'string') {
+      throw new Error('Username is required.');
+    }
+    const trimmed = username.trim();
+    if (!trimmed) {
+      throw new Error('Username cannot be empty.');
+    }
+    if (trimmed.length > 24) {
+      throw new Error('Username is too long.');
+    }
+    return trimmed;
+  }
+
+  _createUser(username) {
+    const now = Date.now();
+    const user = {
+      id: randomUUID(),
+      username,
+      balance: 1000,
+      stats: {
+        wins: 0,
+        losses: 0,
+        gamesPlayed: 0,
+        netEarnings: 0,
+        totalEarned: 0,
+        totalWagered: 0,
+      },
+      lobbyId: null,
+      activeGames: new Set(),
+      completedGames: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.users.set(user.id, user);
+    this.usersByName.set(username.toLowerCase(), user);
+    return user;
+  }
+
+  _getUserByUsername(username) {
+    return this.usersByName.get(username.toLowerCase()) || null;
+  }
+
+  createSession(username) {
+    const cleanName = this._ensureUsername(username);
+    let user = this._getUserByUsername(cleanName);
+    if (!user) {
+      user = this._createUser(cleanName);
+    } else {
+      user.updatedAt = Date.now();
+    }
+    const token = randomUUID();
+    this.sessions.set(token, { token, userId: user.id, createdAt: Date.now() });
+    return { token, user: this._publicUser(user) };
+  }
+
+  endSession(token) {
+    this.sessions.delete(token);
+  }
+
+  getUserBySession(token) {
+    if (!token) return null;
+    const session = this.sessions.get(token);
+    if (!session) return null;
+    const user = this.users.get(session.userId);
+    if (!user) {
+      this.sessions.delete(token);
+      return null;
+    }
+    return this._publicUser(user);
+  }
+
+  _publicUser(user) {
+    return {
+      id: user.id,
+      username: user.username,
+      balance: user.balance,
+      lobbyId: user.lobbyId,
+      activeGames: Array.from(user.activeGames),
+      stats: { ...user.stats },
+      completedGames: user.completedGames.slice(-10),
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
+
+  requireUser(token) {
+    return this._requireUserBySession(token);
+  }
+
+  getProfile(username) {
+    const clean = this._ensureUsername(username);
+    const user = this._getUserByUsername(clean);
+    if (!user) return null;
+    this._sweepAbandonedLobbies();
+    const lobbies = this.listUserLobbies(user.id);
+    const games = this.listUserGames(user.id).slice(0, 10);
+    return {
+      user: this._publicUser(user),
+      lobbies,
+      games,
+    };
+  }
+
+  _requireUserBySession(token) {
+    const session = this.sessions.get(token);
+    if (!session) {
+      throw new Error('Not authenticated.');
+    }
+    const user = this.users.get(session.userId);
+    if (!user) {
+      this.sessions.delete(token);
+      throw new Error('User account missing.');
+    }
+    return user;
+  }
+
+  listLobbies() {
+    this._sweepAbandonedLobbies();
+    return Array.from(this.lobbies.values())
+      .filter((lobby) => lobby.status === 'open')
+      .map((lobby) => this._publicLobby(lobby));
+  }
+
+  listUserLobbies(userId) {
+    this._sweepAbandonedLobbies();
+    return Array.from(this.lobbies.values())
+      .filter((lobby) => lobby.hostId === userId)
+      .map((lobby) => this._publicLobby(lobby));
+  }
+
+  listUserGames(userId) {
+    const result = [];
+    for (const game of this.games.values()) {
+      if (game.players.some((p) => p.userId === userId)) {
+        result.push(this._publicGame(game));
+      }
+    }
+    return result.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  getGame(gameId, { hydrate = true } = {}) {
+    const game = this.games.get(gameId);
+    if (!game) return null;
+    if (hydrate) {
+      this._evaluateDeadlines(game);
+    }
+    return this._publicGame(game);
+  }
+
+  _publicLobby(lobby) {
+    return {
+      id: lobby.id,
+      hostId: lobby.hostId,
+      hostUsername: lobby.hostUsername,
+      buyIn: lobby.buyIn,
+      status: lobby.status,
+      createdAt: lobby.createdAt,
+      opponentId: lobby.opponentId || null,
+      gameId: lobby.gameId || null,
+    };
+  }
+
+  _publicGame(game) {
+    return {
+      id: game.id,
+      lobbyId: game.lobbyId || null,
+      mode: game.mode,
+      status: game.status,
+      players: game.players.map((player) => ({
+        userId: player.userId,
+        username: player.username,
+        wins: player.wins,
+        isAI: player.isAI || false,
+      })),
+      rounds: game.rounds.map((round) => ({
+        round: round.round,
+        moves: round.moves,
+        winnerId: round.winnerId || null,
+        deadline: round.deadline,
+      })),
+      currentRound: game.currentRound,
+      winnerId: game.winnerId || null,
+      buyIn: game.buyIn,
+      pot: game.pot,
+      systemFee: game.systemFee,
+      createdAt: game.createdAt,
+      updatedAt: game.updatedAt,
+      completedAt: game.completedAt || null,
+      resultReason: game.resultReason || null,
+    };
+  }
+
+  createLobby(token, { buyIn }) {
+    const user = this._requireUserBySession(token);
+    const amount = Number(buyIn);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error('Buy-in must be a positive number.');
+    }
+    if (user.balance < amount) {
+      throw new Error('Insufficient balance for buy-in.');
+    }
+    if (user.activeGames.size > 0) {
+      throw new Error('Finish your active game before creating a new lobby.');
+    }
+    if (user.lobbyId) {
+      const existing = this.lobbies.get(user.lobbyId);
+      if (existing && existing.status === 'open') {
+        throw new Error('You already have an active lobby.');
+      }
+    }
+    const now = Date.now();
+    const lobby = {
+      id: randomUUID(),
+      hostId: user.id,
+      hostUsername: user.username,
+      buyIn: amount,
+      status: 'open',
+      createdAt: now,
+      updatedAt: now,
+      opponentId: null,
+      gameId: null,
+    };
+    this.lobbies.set(lobby.id, lobby);
+    user.lobbyId = lobby.id;
+    user.updatedAt = now;
+    return this._publicLobby(lobby);
+  }
+
+  cancelLobby(token, lobbyId) {
+    const user = this._requireUserBySession(token);
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) {
+      throw new Error('Lobby not found.');
+    }
+    if (lobby.hostId !== user.id) {
+      throw new Error('Only the host can cancel the lobby.');
+    }
+    if (lobby.status !== 'open') {
+      throw new Error('Only open lobbies can be cancelled.');
+    }
+    this.lobbies.delete(lobby.id);
+    if (user.lobbyId === lobby.id) {
+      user.lobbyId = null;
+    }
+    user.updatedAt = Date.now();
+    return { success: true };
+  }
+
+  joinLobby(token, lobbyId) {
+    const user = this._requireUserBySession(token);
+    const lobby = this.lobbies.get(lobbyId);
+    if (!lobby) {
+      throw new Error('Lobby not found.');
+    }
+    if (lobby.status !== 'open') {
+      throw new Error('Lobby is not open.');
+    }
+    if (lobby.hostId === user.id) {
+      throw new Error('You cannot join your own lobby.');
+    }
+    if (user.balance < lobby.buyIn) {
+      throw new Error('Insufficient balance.');
+    }
+    if (user.activeGames.size > 0) {
+      throw new Error('You already have a running game.');
+    }
+    const host = this.users.get(lobby.hostId);
+    if (!host) {
+      throw new Error('Lobby host not found.');
+    }
+    if (host.balance < lobby.buyIn) {
+      throw new Error('Host cannot cover the buy-in.');
+    }
+    const game = this._startPvpGame(lobby, host, user);
+    return this._publicGame(game);
+  }
+
+  startAiGame(token, { difficulty = 'normal' } = {}) {
+    const user = this._requireUserBySession(token);
+    if (user.activeGames.size > 0) {
+      throw new Error('Finish your active game before starting AI duel.');
+    }
+    const game = this._startAiGame(user, difficulty);
+    return this._publicGame(game);
+  }
+
+  _startPvpGame(lobby, host, opponent) {
+    const now = Date.now();
+    lobby.status = 'in_game';
+    lobby.opponentId = opponent.id;
+    host.lobbyId = null;
+    lobby.updatedAt = now;
+
+    const pot = lobby.buyIn * 2;
+    const systemFee = Math.round(pot * SYSTEM_FEE_RATIO);
+
+    host.balance -= lobby.buyIn;
+    opponent.balance -= lobby.buyIn;
+    host.stats.totalWagered += lobby.buyIn;
+    opponent.stats.totalWagered += lobby.buyIn;
+
+    const game = {
+      id: randomUUID(),
+      lobbyId: lobby.id,
+      mode: 'pvp',
+      status: 'in_progress',
+      buyIn: lobby.buyIn,
+      pot,
+      systemFee,
+      players: [
+        { userId: host.id, username: host.username, wins: 0, isAI: false },
+        { userId: opponent.id, username: opponent.username, wins: 0, isAI: false },
+      ],
+      currentRound: 1,
+      rounds: [this._createRound(1)],
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+      winnerId: null,
+      resultReason: null,
+    };
+    this.games.set(game.id, game);
+    lobby.gameId = game.id;
+
+    host.activeGames.add(game.id);
+    opponent.activeGames.add(game.id);
+    host.updatedAt = now;
+    opponent.updatedAt = now;
+    return game;
+  }
+
+  _startAiGame(user, difficulty) {
+    const now = Date.now();
+    const buyIn = 0;
+    const pot = 0;
+    const systemFee = 0;
+    const aiPlayer = {
+      userId: 'ai-engine',
+      username: 'Pi Duel AI',
+      wins: 0,
+      isAI: true,
+      difficulty,
+    };
+    const game = {
+      id: randomUUID(),
+      lobbyId: null,
+      mode: 'ai',
+      status: 'in_progress',
+      buyIn,
+      pot,
+      systemFee,
+      players: [
+        { userId: user.id, username: user.username, wins: 0, isAI: false },
+        aiPlayer,
+      ],
+      currentRound: 1,
+      rounds: [this._createRound(1)],
+      createdAt: now,
+      updatedAt: now,
+      completedAt: null,
+      winnerId: null,
+      resultReason: null,
+    };
+    this.games.set(game.id, game);
+    user.activeGames.add(game.id);
+    user.updatedAt = now;
+    return game;
+  }
+
+  _createRound(roundNumber) {
+    const now = Date.now();
+    return {
+      round: roundNumber,
+      moves: {},
+      winnerId: null,
+      startedAt: now,
+      deadline: now + ROUND_TIME_LIMIT_MS,
+    };
+  }
+
+  submitMove(token, gameId, moveChoice) {
+    const user = this._requireUserBySession(token);
+    const game = this.games.get(gameId);
+    if (!game) {
+      throw new Error('Game not found.');
+    }
+    if (game.status !== 'in_progress') {
+      throw new Error('Game is not active.');
+    }
+    if (!MOVE_VALUES.includes(moveChoice)) {
+      throw new Error('Invalid move.');
+    }
+    const player = game.players.find((p) => p.userId === user.id);
+    if (!player) {
+      throw new Error('You are not part of this game.');
+    }
+
+    const round = game.rounds[game.rounds.length - 1];
+    if (!round.moves[user.id]) {
+      round.moves[user.id] = { choice: moveChoice, madeAt: Date.now() };
+      round.deadline = Date.now() + ROUND_TIME_LIMIT_MS;
+    } else {
+      // Prevent changing move after submission
+      throw new Error('Move already submitted for this round.');
+    }
+
+    game.updatedAt = Date.now();
+
+    if (game.mode === 'ai') {
+      this._handleAiTurn(game, round, player);
+    }
+
+    this._evaluateRound(game, round);
+    return this._publicGame(game);
+  }
+
+  _handleAiTurn(game, round, humanPlayer) {
+    const ai = game.players.find((p) => p.isAI);
+    if (!ai) return;
+    if (round.moves[ai.userId]) return;
+    const choice = this._generateAiMove(game, ai, humanPlayer);
+    round.moves[ai.userId] = { choice, madeAt: Date.now() };
+  }
+
+  _generateAiMove(game, aiPlayer, humanPlayer) {
+    const history = [];
+    for (const round of game.rounds) {
+      const move = round.moves[humanPlayer.userId];
+      if (move) {
+        history.push(move.choice);
+      }
+    }
+    if (history.length === 0 || aiPlayer.difficulty === 'random') {
+      return MOVE_VALUES[Math.floor(Math.random() * MOVE_VALUES.length)];
+    }
+    const counts = history.reduce(
+      (acc, value) => {
+        acc[value] = (acc[value] || 0) + 1;
+        return acc;
+      },
+      {}
+    );
+    let predicted = 'rock';
+    let maxCount = -1;
+    for (const move of MOVE_VALUES) {
+      const count = counts[move] || 0;
+      if (count > maxCount) {
+        predicted = move;
+        maxCount = count;
+      }
+    }
+    const counter = {
+      rock: 'paper',
+      paper: 'scissors',
+      scissors: 'rock',
+    };
+    return counter[predicted];
+  }
+
+  _evaluateRound(game, round) {
+    this._evaluateDeadlines(game);
+    if (!round.moves) return;
+    const players = game.players.map((p) => p.userId);
+    const [p1, p2] = players;
+    if (!round.moves[p1] || !round.moves[p2]) {
+      return;
+    }
+    const move1 = round.moves[p1].choice;
+    const move2 = round.moves[p2].choice;
+    if (move1 === move2) {
+      round.winnerId = null;
+      this._startNextRound(game, 'Draw');
+      return;
+    }
+    const winnerId = WIN_MAP[move1] === move2 ? p1 : p2;
+    round.winnerId = winnerId;
+    this._registerRoundWin(game, winnerId);
+  }
+
+  _registerRoundWin(game, winnerId) {
+    const player = game.players.find((p) => p.userId === winnerId);
+    if (player) {
+      player.wins += 1;
+    }
+    if (player && player.wins >= MAX_ROUND_WINS) {
+      this._finishGame(game, winnerId, 'Victory');
+    } else {
+      this._startNextRound(game, 'Round won');
+    }
+  }
+
+  _startNextRound(game, reason) {
+    if (game.status !== 'in_progress') return;
+    const next = this._createRound(game.rounds.length + 1);
+    game.rounds.push(next);
+    game.currentRound = next.round;
+    game.resultReason = reason;
+    game.updatedAt = Date.now();
+  }
+
+  _finishGame(game, winnerId, reason) {
+    if (game.status !== 'in_progress') return;
+    const now = Date.now();
+    const loser = game.players.find((p) => p.userId !== winnerId);
+    const winner = this.users.get(winnerId);
+    const loserUser = loser && this.users.get(loser.userId);
+    const systemFee = Math.round(game.pot * SYSTEM_FEE_RATIO);
+    const payout = Math.max(game.pot - systemFee, 0);
+
+    if (winner) {
+      winner.balance += payout;
+      winner.stats.wins += 1;
+      winner.stats.gamesPlayed += 1;
+      if (game.mode === 'pvp') {
+        winner.stats.netEarnings += payout - game.buyIn;
+        winner.stats.totalEarned += payout;
+      }
+      winner.activeGames.delete(game.id);
+      winner.completedGames.push({
+        gameId: game.id,
+        result: 'win',
+        opponent: loser ? loser.username : 'Pi Duel AI',
+        completedAt: now,
+        mode: game.mode,
+      });
+      winner.updatedAt = now;
+    }
+
+    if (loserUser) {
+      loserUser.stats.losses += 1;
+      loserUser.stats.gamesPlayed += 1;
+      if (game.mode === 'pvp') {
+        loserUser.stats.netEarnings -= game.buyIn;
+      }
+      loserUser.activeGames.delete(game.id);
+      loserUser.completedGames.push({
+        gameId: game.id,
+        result: 'loss',
+        opponent: winner ? winner.username : 'Pi Duel AI',
+        completedAt: now,
+        mode: game.mode,
+      });
+      loserUser.updatedAt = now;
+    }
+
+    if (game.lobbyId) {
+      const lobby = this.lobbies.get(game.lobbyId);
+      if (lobby) {
+        lobby.status = 'completed';
+        lobby.updatedAt = now;
+      }
+    }
+
+    if (game.mode === 'pvp') {
+      this.houseEarnings += systemFee;
+    }
+
+    game.status = 'completed';
+    game.winnerId = winnerId;
+    game.completedAt = now;
+    game.updatedAt = now;
+    game.resultReason = reason;
+  }
+
+  _evaluateDeadlines(game) {
+    if (game.status !== 'in_progress') return;
+    const round = game.rounds[game.rounds.length - 1];
+    const now = Date.now();
+    if (now <= round.deadline) {
+      return;
+    }
+    const players = game.players.map((p) => p.userId);
+    const missing = players.filter((id) => !round.moves[id]);
+    if (missing.length === 0) {
+      return;
+    }
+    const completed = players.filter((id) => round.moves[id]);
+    if (completed.length === 1) {
+      round.winnerId = completed[0];
+      this._registerRoundWin(game, round.winnerId);
+    } else {
+      // nobody moved -> refresh deadline without awarding round
+      round.deadline = now + ROUND_TIME_LIMIT_MS;
+    }
+  }
+
+  _sweepAbandonedLobbies() {
+    const now = Date.now();
+    for (const [id, lobby] of this.lobbies.entries()) {
+      if (lobby.status !== 'open') continue;
+      if (now - lobby.createdAt > 60 * 60 * 1000) {
+        this.lobbies.delete(id);
+        const host = this.users.get(lobby.hostId);
+        if (host && host.lobbyId === id) {
+          host.lobbyId = null;
+        }
+      }
+    }
+  }
+}
+
+module.exports = {
+  store: new GameStore(),
+  MOVE_VALUES,
+};


### PR DESCRIPTION
## Summary
- Build an in-memory game store and Node.js HTTP API that powers mock login, lobby management, PvP/AI RPS matches, escrow payouts, and AFK handling.
- Implement a vanilla JavaScript SPA with dashboard, lobby and game flows, AI practice mode, and profile/statistics views styled in a PancakeSwap-inspired theme.
- Document the MVP architecture and startup instructions while adding an npm start script for the server.

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d1bcbf03e08327ab38423904bcec6e